### PR TITLE
Add Docker setup and Terraform deployment to Azure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+build
+dist
+Dockerfile*
+server/
+infrastructure/
+*.log
+.env

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,13 @@
+# Multi-stage build for React front-end
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY public ./public
+COPY src ./src
+RUN npm run build
+
+FROM nginx:alpine AS production
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,27 @@ following environment variables for your LMS platform:
 
 The tool exposes login initiation and launch endpoints under `/lti/login` and `/lti/launch`.  Grade/passback and Names & Role
 services are available at `/lti/grade` and `/lti/names` respectively.
+
+## Docker
+
+Build the front-end and back-end images and start both services:
+
+```bash
+docker compose up --build
+```
+
+The back-end expects the following environment variables:
+- `AZURE_SQL_CONNECTION_STRING`
+- `COSMOS_DB_ENDPOINT`
+- `COSMOS_DB_KEY`
+
+## Azure deployment
+
+Terraform scripts under `infrastructure/` provision an Azure resource group,
+container registry, and App Services for the front-end and back-end. Set the
+required variables and run:
+
+```bash
+cd infrastructure
+./deploy.sh -auto-approve
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.9'
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "3000:80"
+    environment:
+      - REACT_APP_API_URL=http://backend:3001
+    depends_on:
+      - backend
+  backend:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3001"
+    environment:
+      - PORT=3001
+      - AZURE_SQL_CONNECTION_STRING=${AZURE_SQL_CONNECTION_STRING}
+      - COSMOS_DB_ENDPOINT=${COSMOS_DB_ENDPOINT}
+      - COSMOS_DB_KEY=${COSMOS_DB_KEY}

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+terraform init
+terraform apply "$@"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,74 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.project}-rg"
+  location = var.location
+}
+
+resource "azurerm_container_registry" "acr" {
+  name                = "${var.project}acr"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = "Basic"
+  admin_enabled       = true
+}
+
+resource "azurerm_service_plan" "plan" {
+  name                = "${var.project}-plan"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  os_type             = "Linux"
+  sku_name            = "B1"
+}
+
+resource "azurerm_linux_web_app" "frontend" {
+  name                = "${var.project}-frontend"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  service_plan_id     = azurerm_service_plan.plan.id
+
+  site_config {
+    linux_fx_version = "DOCKER|${azurerm_container_registry.acr.login_server}/${var.frontend_image}:${var.frontend_tag}"
+  }
+
+  app_settings = {
+    WEBSITES_PORT                 = "80"
+    DOCKER_REGISTRY_SERVER_URL      = azurerm_container_registry.acr.login_server
+    DOCKER_REGISTRY_SERVER_USERNAME = azurerm_container_registry.acr.admin_username
+    DOCKER_REGISTRY_SERVER_PASSWORD = azurerm_container_registry.acr.admin_password
+    REACT_APP_API_URL               = var.backend_url
+  }
+}
+
+resource "azurerm_linux_web_app" "backend" {
+  name                = "${var.project}-backend"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  service_plan_id     = azurerm_service_plan.plan.id
+
+  site_config {
+    linux_fx_version = "DOCKER|${azurerm_container_registry.acr.login_server}/${var.backend_image}:${var.backend_tag}"
+  }
+
+  app_settings = {
+    WEBSITES_PORT                 = "3001"
+    DOCKER_REGISTRY_SERVER_URL      = azurerm_container_registry.acr.login_server
+    DOCKER_REGISTRY_SERVER_USERNAME = azurerm_container_registry.acr.admin_username
+    DOCKER_REGISTRY_SERVER_PASSWORD = azurerm_container_registry.acr.admin_password
+    AZURE_SQL_CONNECTION_STRING     = var.azuresql_connection_string
+    COSMOS_DB_ENDPOINT              = var.cosmos_db_endpoint
+    COSMOS_DB_KEY                   = var.cosmos_db_key
+  }
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,0 +1,55 @@
+variable "project" {
+  description = "Project name prefix"
+  type        = string
+  default     = "hwte"
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+  default     = "East US"
+}
+
+variable "frontend_image" {
+  description = "Front-end image name in ACR"
+  type        = string
+}
+
+variable "frontend_tag" {
+  description = "Tag for the front-end image"
+  type        = string
+  default     = "latest"
+}
+
+variable "backend_image" {
+  description = "Back-end image name in ACR"
+  type        = string
+}
+
+variable "backend_tag" {
+  description = "Tag for the back-end image"
+  type        = string
+  default     = "latest"
+}
+
+variable "backend_url" {
+  description = "URL of the back-end service"
+  type        = string
+}
+
+variable "azuresql_connection_string" {
+  description = "Azure SQL connection string"
+  type        = string
+  sensitive   = true
+}
+
+variable "cosmos_db_endpoint" {
+  description = "Cosmos DB endpoint"
+  type        = string
+}
+
+variable "cosmos_db_key" {
+  description = "Cosmos DB key"
+  type        = string
+  sensitive   = true
+}

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,13 @@
+# Multi-stage build for backend service
+FROM node:18-alpine AS install
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=install /app /app
+ENV PORT=3001
+EXPOSE 3001
+CMD ["node", "index.js"]


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfiles for React front-end and Node backend
- Introduce docker-compose for local orchestration and secret injection
- Provision Azure resources with Terraform and script for automated deployment

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `cd server && npm test --silent` *(fails: no test specified)*
- `docker compose config` *(fails: command not found)*
- `cd infrastructure && terraform fmt -check && terraform init -input=false && terraform validate` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a2a8ca08832c9ffb1f0e807b156b